### PR TITLE
docs: update Clockchain — 769 nodes, image_url, interactive API docs

### DIFF
--- a/api-reference/clockchain.mdx
+++ b/api-reference/clockchain.mdx
@@ -23,19 +23,20 @@ curl https://timepoint-clockchain-deploy-private-production.up.railway.app/api/v
 
 ```json
 {
-  "total_nodes": 196,
-  "total_edges": 671,
-  "layer_counts": {"2": 196},
+  "total_nodes": 769,
+  "total_edges": 5602,
+  "layer_counts": {"2": 769},
   "edge_type_counts": {
     "causes": 73,
     "same_location": 42,
     "contemporaneous": 474,
     "thematic": 82
   },
-  "source_type_counts": {"historical": 196},
-  "date_range": {"min_year": -133, "max_year": 2019},
-  "avg_confidence": null,
-  "last_updated": "2026-03-07T04:35:49Z"
+  "source_type_counts": {"historical": 769},
+  "date_range": {"min_year": -700, "max_year": 2026},
+  "avg_confidence": 0.85,
+  "last_updated": "2026-03-10T00:00:00Z",
+  "nodes_with_images": 561
 }
 ```
 
@@ -74,10 +75,11 @@ curl "https://timepoint-clockchain-deploy-private-production.up.railway.app/api/
       "year": 1969,
       "layer": 2,
       "figures": ["Neil Armstrong", "Buzz Aldrin"],
-      "tags": ["space", "nasa", "cold-war"]
+      "tags": ["space", "nasa", "cold-war"],
+      "image_url": "https://cdn.timepointai.com/scenes/apollo-11-moon-landing.jpg"
     }
   ],
-  "total": 196,
+  "total": 769,
   "limit": 5,
   "offset": 0
 }
@@ -103,6 +105,13 @@ These require `X-Service-Key` header:
 | `/today` | GET | Today in history |
 | `/generate` | POST | Generate new moment via Flash |
 | `/ingest/tdf` | POST | Ingest TDF record |
+
+## Interactive API Docs
+
+The Clockchain provides built-in interactive documentation:
+
+- **Swagger UI:** `/docs` — try endpoints directly in the browser
+- **ReDoc:** `/redoc` — readable reference documentation
 
 ### TDF Export
 

--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -44,7 +44,7 @@ All APIs return JSON. Clockchain public endpoints return paginated results:
 ```json
 {
   "items": [...],
-  "total": 196,
+  "total": 769,
   "limit": 10,
   "offset": 0
 }

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -19,7 +19,7 @@ Timepoint is an open-source ecosystem of six integrated services that work toget
     **The SNAG Engine** — social simulation with 19 composable mechanisms, 5 temporal modes, causal provenance, and structured social graphs.
   </Card>
   <Card title="Clockchain" icon="link" href="/products/clockchain">
-    **The Temporal Causal Graph** — PostgreSQL-backed directed graph that accumulates rendered past and simulated future into a growing Bayesian prior.
+    **The Temporal Causal Graph** — 769 nodes, 5,602 edges, 700 BCE to 2026. PostgreSQL-backed directed graph that accumulates rendered past and simulated future into a growing Bayesian prior.
   </Card>
   <Card title="TDF" icon="file-code" href="/products/tdf">
     **The Data Format** — JSON-LD interchange format with content-addressed SHA-256 hashing. The universal data contract.

--- a/products/clockchain.mdx
+++ b/products/clockchain.mdx
@@ -5,7 +5,7 @@ description: "Persistent temporal causal graph — PostgreSQL-backed directed gr
 
 # Clockchain
 
-**Temporal causal graph for AI agents.** PostgreSQL-backed directed graph of historical moments — canonical spatiotemporal URLs, typed causal edges, autonomous expansion, and browse/search/discovery APIs.
+**Temporal causal graph for AI agents.** PostgreSQL-backed directed graph of historical moments — canonical spatiotemporal URLs, typed causal edges, autonomous expansion, and browse/search/discovery APIs. Currently holds **769 nodes** and **5,602 edges** spanning 700 BCE to 2026, with 73% image coverage and growing.
 
 <CardGroup cols={2}>
   <Card title="GitHub" icon="github" href="https://github.com/timepointai/timepoint-clockchain">
@@ -38,7 +38,7 @@ Two PostgreSQL tables: `nodes` (canonical spatiotemporal URLs as PKs) and `edges
 |-------|---------|--------|
 | 0 | URL path + event name | Auto-generated |
 | 1 | Metadata: figures, tags, description | Expander (LLM) |
-| 2 | Full Flash scene with dialog, characters, image | Flash renderer |
+| 2 | Full Flash scene with dialog, characters, image, CDN-hosted image_url | Flash renderer |
 
 ### Edge Types
 


### PR DESCRIPTION
## Summary
- Update graph stats: 769 nodes, 5,602 edges, 700 BCE–2026, 73% image coverage
- Add `image_url` (CDN-hosted) to moment API response examples
- Add `nodes_with_images` and `avg_confidence` to stats response
- Document interactive API docs at `/docs` (Swagger) and `/redoc`