### PR TITLE
docs(gap-3): navigation + introduction refresh (errors, intro cards, nav)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,57 @@
-# Timepoint AI Documentation
+# Timepoint AI — Documentation
 
-Official documentation for the [Timepoint AI](https://timepointai.com) platform — synthetic time travel through AI-powered temporal simulation.
+Source for [docs.timepointai.com](https://docs.timepointai.com). Built with [Mintlify](https://mintlify.com/).
 
-**Live docs:** [docs.timepointai.com](https://docs.timepointai.com)
+## Start Here
 
-## What's Covered
+If you're reading these files directly (not the rendered site), begin with these four pages — they cover the shortest path from zero to a working integration:
 
-### Getting Started
-Introduction, quickstart guide, core concepts, and accessibility.
+| Page | What's in it |
+|------|--------------|
+| [`introduction.mdx`](./introduction.mdx) | What Timepoint is, the service map, and the architecture diagram |
+| [`quickstart.mdx`](./quickstart.mdx) | Render your first moment via the hosted API; local-dev setup for Flash, Pro, and Clockchain |
+| [`api-reference/authentication.mdx`](./api-reference/authentication.mdx) | The four credential types: Bearer JWT, API Key, X-Service-Key, X-Admin-Key (anchor: `#auth-schemes`) |
+| [`api-reference/mcp.mdx`](./api-reference/mcp.mdx) | The Clockchain MCP server + the six tools it exposes (anchor: `#mcp-tools`) |
+| [`errors.mdx`](./errors.mdx) | HTTP status codes, rate-limit headers, decision tree for common failures |
 
-### Products
-- **Flash** — Generate historically grounded moments with characters, dialog, and images
-- **Pro Cloud** — Run multi-entity SNAG simulations at scale
-- **Clockchain** — Browse and query the temporal causal graph
-- **SNAG-Bench** — Benchmark suite for temporal simulation accuracy
-- **Proteus** — Adaptive narrative engine
-- **TDF** — Temporal Data Format specification
+## Repo Layout
 
-### API Reference
-- Overview, authentication, and Gateway routing
-- Clockchain, Flash, and Pro API endpoints
-- MCP integration for AI agents (Claude, Cursor, Copilot)
-
-## Built With
-
-These docs are built with [Mintlify](https://mintlify.com) and deployed automatically.
-
-## Local Development
-
-```bash
-npx mintlify dev
+```
+docs/
+├── introduction.mdx          Landing page — service map + architecture
+├── quickstart.mdx            Hosted-API curl + local dev
+├── concepts.mdx              Timepoints, SNAG, temporal modes
+├── errors.mdx                Error reference + decision tree
+├── accessibility.mdx         WCAG conformance
+├── api-reference/
+│   ├── overview.mdx          Gateway front-door, domain map, rate limits
+│   ├── authentication.mdx    Auth schemes, OAuth providers, health
+│   ├── gateway.mdx           Gateway endpoints
+│   ├── flash.mdx             Flash rendering API
+│   ├── clockchain.mdx        Clockchain read/write API
+│   ├── pro.mdx               Pro / SNAG simulation API
+│   └── mcp.mdx               MCP server + tools
+├── products/                 Product deep dives (Flash, Pro, Clockchain, …)
+├── logo/                     Brand assets
+└── docs.json                 Mintlify navigation + theme config
 ```
 
-## License
+## Navigation
 
-Apache 2.0 — see [LICENSE](LICENSE)
+The sidebar is defined in [`docs.json`](./docs.json) under `navigation.groups`. Add a new page by:
+
+1. Dropping the `.mdx` file in the right folder.
+2. Adding its slug (no `.mdx` extension) to the appropriate `pages` array in `docs.json`.
+
+## Local Preview
+
+```bash
+npm i -g mintlify
+mintlify dev
+```
+
+Opens the site at http://localhost:3000.
+
+## Contributing
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md). Licensed under Apache-2.0 — see [`LICENSE`](./LICENSE).

--- a/docs.json
+++ b/docs.json
@@ -46,7 +46,7 @@
     "groups": [
       {
         "group": "Getting Started",
-        "pages": ["introduction", "quickstart", "concepts", "accessibility"]
+        "pages": ["introduction", "quickstart", "concepts", "errors", "accessibility"]
       },
       {
         "group": "Products",

--- a/errors.mdx
+++ b/errors.mdx
@@ -1,0 +1,124 @@
+---
+title: Errors & Troubleshooting
+description: "HTTP status codes, error shapes, rate limit headers, and a decision tree for common Timepoint API failures."
+---
+
+# Errors & Troubleshooting
+
+Every Timepoint service is fronted by the [API Gateway](/api-reference/overview) at `api.timepointai.com` (Clockchain public reads are also available directly at `clockchain.timepointai.com`). This page documents the error shapes, status codes, and rate-limit semantics you should expect — and a decision tree for the most common failures.
+
+## Error Response Shape
+
+All Timepoint APIs return JSON. Non-2xx responses include a `detail` or `error` field describing what went wrong:
+
+```json
+{
+  "detail": "Invalid or expired token",
+  "code": "auth.jwt_invalid"
+}
+```
+
+Some endpoints return a bare `{"detail": "..."}` (FastAPI convention); others return a richer `{"error": "...", "code": "..."}` envelope. Always check `response.status` first, then parse the body.
+
+## HTTP Status Codes
+
+| Status | Meaning | Common Causes | Fix |
+|--------|---------|--------------|-----|
+| `400 Bad Request` | Malformed payload | Missing required field, invalid JSON | Check the request body against the [API reference](/api-reference/overview) |
+| `401 Unauthorized` | Missing or invalid credentials | No `Authorization` header, expired JWT, wrong API key | Re-authenticate via the [Gateway](/api-reference/authentication#bearer-jwt-end-users) or refresh your token |
+| `403 Forbidden` | Valid auth, insufficient privilege | Using a consumer JWT against an admin-only endpoint, tenant mismatch | Confirm the [key type](/api-reference/authentication#auth-schemes) matches the endpoint |
+| `404 Not Found` | Resource does not exist | Wrong canonical path, moment not in Clockchain | Search first via `/api/v1/moments?q=...` |
+| `409 Conflict` | Write collides with existing state | Duplicate moment, stale version | Re-fetch, then retry |
+| `422 Unprocessable Entity` | Payload validated but rejected | Schema mismatch, enum out of range | Compare against the example in the relevant product page |
+| `429 Too Many Requests` | Rate limit exceeded | Burst traffic above your tier | Back off using `X-RateLimit-Reset` (see below) |
+| `500 Internal Server Error` | Unhandled server error | Transient bug, upstream provider outage | Retry with exponential backoff; if persistent, file an issue |
+| `502 / 503 / 504` | Gateway or upstream unavailable | Backend deploy, model provider hiccup | Retry; check [status endpoints](/api-reference/authentication#health-check) |
+
+## Decision Tree
+
+Use this to quickly localize a failure:
+
+```
+Got a 4xx or 5xx from api.timepointai.com?
+│
+├─ 401 Unauthorized ───────────► Is your JWT expired?          ──► Re-auth through OAuth
+│                                Is the API key rotated?        ──► Regenerate in dashboard
+│                                Wrong header name?             ──► Bearer → `Authorization`; API key → `X-API-Key`
+│
+├─ 403 Forbidden ──────────────► Endpoint needs admin/service?  ──► Switch to X-Admin-Key / X-Service-Key
+│                                                                   (see /api-reference/authentication#auth-schemes)
+│
+├─ 404 Not Found ──────────────► Moment lookup?                 ──► Search first; canonical paths are slashy
+│                                Wrong subdomain?               ──► Consumer calls go through api.timepointai.com
+│
+├─ 422 Unprocessable ──────────► Field type mismatch            ──► Compare to quickstart example (/quickstart)
+│
+├─ 429 Too Many Requests ─────► Respect `X-RateLimit-Reset`     ──► Sleep until that epoch, then retry
+│
+├─ 5xx from api.timepointai.com ► Retry 2x with backoff         ──► If persistent, check /api-reference/authentication#health-check
+│
+└─ Connection error ───────────► CORS preflight?                ──► Verify origin is *.timepointai.com
+                                 DNS / TLS?                     ──► Check subdomain spelling
+```
+
+## Rate Limits
+
+The Gateway enforces per-tier limits. All rate-limited responses include these headers:
+
+| Header | Meaning |
+|--------|---------|
+| `X-RateLimit-Limit` | Requests allowed in the current window |
+| `X-RateLimit-Remaining` | Requests left in the window |
+| `X-RateLimit-Reset` | Unix epoch when the window resets |
+
+Current tiers (see [Rate Limits](/api-reference/overview#rate-limits) for the canonical table):
+
+| Tier | Limit | Applies To |
+|------|-------|------------|
+| Public | 60 / min | Clockchain unauthenticated reads |
+| Auth reads | 300 / min | Authenticated `GET` |
+| Auth writes | 30 / min | Authenticated `POST` / `PUT` / `DELETE` |
+
+**Client guidance:** on a `429`, do not retry immediately — compute `wait = X-RateLimit-Reset - now()` and sleep. Burst retries cause further throttling.
+
+## Authentication Errors
+
+Authentication failures come from the Gateway and follow this pattern:
+
+```json
+{
+  "detail": "Invalid or expired token",
+  "code": "auth.jwt_invalid"
+}
+```
+
+Common codes:
+
+| Code | Meaning | Next Step |
+|------|---------|-----------|
+| `auth.missing` | No credentials presented | Add `Authorization: Bearer ...` or `X-API-Key: ...` |
+| `auth.jwt_invalid` | JWT signature failed | Re-auth via OAuth — the signing key may have rotated |
+| `auth.jwt_expired` | JWT `exp` passed | Refresh token via `/api/v1/auth/refresh` |
+| `auth.key_revoked` | API key deactivated | Generate a new key in the dashboard |
+| `auth.insufficient_credits` | Account out of credits | Top up via [Billing](/api-reference/overview) |
+
+See [Authentication → Auth Schemes](/api-reference/authentication#auth-schemes) for the full key-type matrix (Bearer JWT, API Key, X-Service-Key, X-Admin-Key).
+
+## MCP-Specific Errors
+
+When using the Clockchain MCP server (`clockchain.timepointai.com/mcp/`), tool failures surface as MCP error objects rather than HTTP errors:
+
+```json
+{
+  "isError": true,
+  "content": [{"type": "text", "text": "Tool 'flash_render' requires auth"}]
+}
+```
+
+Unauthenticated tools (`clockchain_stats`, `clockchain_search`, `clockchain_moment`, `clockchain_neighbors`) work without credentials. Authenticated tools (`flash_render`, `pro_simulate`) require a JWT passed to the MCP client. See [MCP Server → Tools](/api-reference/mcp#mcp-tools).
+
+## Still Stuck?
+
+- Check the [health endpoints](/api-reference/authentication#health-check) — a 5xx during a known outage is transient.
+- Compare your request against the [Quickstart](/quickstart) — copy-paste, then diff.
+- File an issue at [github.com/timepointai](https://github.com/timepointai).

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -88,10 +88,26 @@ All client traffic enters through the API Gateway (api.timepointai.com), which h
 
 ## Get Started
 
+New to Timepoint? These four pages cover the shortest path from zero to a working integration:
+
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
-    Clone, install, and render your first moment
+    Clone, install, and render your first moment — one click from here to a working `curl` command.
   </Card>
+  <Card title="Authentication — Key Types" icon="key" href="/api-reference/authentication#auth-schemes">
+    The four credential types (Bearer JWT, API Key, X-Service-Key, X-Admin-Key) and when to use each.
+  </Card>
+  <Card title="MCP Tools" icon="plug" href="/api-reference/mcp#mcp-tools">
+    The six MCP tools (`clockchain_stats`, `clockchain_search`, `clockchain_moment`, `clockchain_neighbors`, `flash_render`, `pro_simulate`).
+  </Card>
+  <Card title="Errors & Troubleshooting" icon="triangle-exclamation" href="/errors">
+    HTTP status codes, rate-limit headers, and a decision tree for common failures.
+  </Card>
+</CardGroup>
+
+### Go Deeper
+
+<CardGroup cols={2}>
   <Card title="Core Concepts" icon="book" href="/concepts">
     Timepoints, temporal modes, and the Clockchain
   </Card>
@@ -100,5 +116,8 @@ All client traffic enters through the API Gateway (api.timepointai.com), which h
   </Card>
   <Card title="GitHub" icon="github" href="https://github.com/timepointai">
     All source code — Apache-2.0 licensed
+  </Card>
+  <Card title="Accessibility" icon="universal-access" href="/accessibility">
+    WCAG 2.1 Level A conformance statement
   </Card>
 </CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -46,7 +46,7 @@
     "groups": [
       {
         "group": "Getting Started",
-        "pages": ["introduction", "quickstart", "concepts", "accessibility"]
+        "pages": ["introduction", "quickstart", "concepts", "errors", "accessibility"]
       },
       {
         "group": "Products",


### PR DESCRIPTION
GAP-3 from Plan C. Closes the nav/discoverability gap after API-8 shipped the new pages. Changes: errors.mdx (HTTP status decision tree), introduction.mdx 'Start Here' CardGroup linking quickstart/auth/mcp/errors, README.md full docs map, docs.json + mint.json nav updated. Sanity: intro→quickstart is one click.